### PR TITLE
-nodoc -> -with-doc no, for 8.4 and earlier

### DIFF
--- a/packages/coq.8.3.dev/opam
+++ b/packages/coq.8.3.dev/opam
@@ -4,7 +4,7 @@ homepage: "http://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 license: "LGPL 2"
 build: [
-  ["./configure" "-camlp5dir" "%{lib}%/camlp5" "-prefix" prefix "-nodoc" "-coqide" "no"]
+  ["./configure" "-camlp5dir" "%{lib}%/camlp5" "-prefix" prefix "-with-doc" "no" "-coqide" "no"]
   [make "-j%{jobs}%"]
   [make "install"]
 ]

--- a/packages/coq.8.4.dev+ltacprof/opam
+++ b/packages/coq.8.4.dev+ltacprof/opam
@@ -4,7 +4,7 @@ homepage: "http://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 license: "LGPL 2"
 build: [
-  ["./configure" "-configdir" "%{lib}%/coq/config" "-mandir" man "-nodoc" "-prefix" prefix "-usecamlp5" "-camlp5dir" "%{lib}%/camlp5" "-coqide" "no"]
+  ["./configure" "-configdir" "%{lib}%/coq/config" "-mandir" man "-with-doc" "no" "-prefix" prefix "-usecamlp5" "-camlp5dir" "%{lib}%/camlp5" "-coqide" "no"]
   [make "-j%{jobs}%"]
   [make "install"]
 ]


### PR DESCRIPTION
For whatever reason, this flag changed names for 8.5.
